### PR TITLE
.github/: add workflow for cargo check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+
+name:  Cargo check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path=rust-client/Cargo.toml
+


### PR DESCRIPTION
Follow up on https://github.com/mxinden/punchr/pull/1#issuecomment-1091912169.
Add GitHub action to run `cargo check` on the rust-client. The main purpose of this is to be alterted in case that any changes in the `punchr.proto` file will break compatibility with the rust client.