### PR TITLE
rust-client: add api-key & listen_multi_addresses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,33 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 
-# commented out until this works again
+name:  Cargo check
 
-# name:  Cargo check
-#
-# on:
-#   push:
-#     branches:
-#       - main
-#   pull_request:
-#     branches:
-#       - main
-#
-# jobs:
-#   check:
-#     name: Check
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout sources
-#         uses: actions/checkout@v2
-#
-#       - name: Install stable toolchain
-#         uses: actions-rs/toolchain@v1
-#         with:
-#           profile: minimal
-#           toolchain: stable
-#           override: true
-#
-#       - name: Run cargo check
-#         uses: actions-rs/cargo@v1
-#         with:
-#           command: check
-#           args: --manifest-path=rust-client/Cargo.toml
-#
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path=rust-client/Cargo.toml
+


### PR DESCRIPTION
Update rust-client to be compatible with the latest main:
- Add api-key to authenticate the client at the server (Closes #13)
- Adapt to other minor protobuf changes

Note: I was only able to briefly test it again our test server, where it worked as expected. Now not working anymore, most likely because of #22. I will fix this in a separate PR, but might take at bit more time.

---

Also re-enabled the CI since we are now compatible again, but not insisting on that. @dennis-tra in case that you prefer it being disabled while things are still changing a lot I am happy to keep it commented out.