### PR TITLE
Allow some bootstrap peer failures + NixOS Module

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 1.4.0; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/1.4.0/direnvrc" "sha256-4XfVDjv75eHMWN4G725VW7BoOV4Vl3vAabK4YXIfPyE="
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,6 @@ rust-client/Cargo.lock
 punchr.gz
 
 dist/
+
+# Nix build result symlink
+result

--- a/README.md
+++ b/README.md
@@ -264,6 +264,31 @@ If the client can't connect to bootstrap peers try this additional command line 
 --bootstrap-peers="/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/ip4/147.75.77.187/tcp/4001/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/ip4/147.75.109.29/tcp/4001/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp"
 ```
 
+#### NixOS
+
+If you're running NixOS, you can get the client systemd service with the NixOS
+Module included in the flake.
+
+Usage:
+```nix
+{
+  inputs.punchr = {
+    url = "github:dennis-tra/punchr";
+  };
+   # ...
+
+  outputs = inputs@{ self , nixpkgs }: {
+      # ...Inside NixOS config
+      {
+         imports = [ inputs.punchr.nixosModules.client ];
+         services.punchr-client.apiKey = "<API-KEY>";
+      }
+  };
+}
+```
+
+You can run the client by itself with `nix run github:dennis-tra/punchr#client`.
+
 ## Server
 
 Systemd service example at `/etc/systemd/system/punchr-server.service`:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Punchr
+# Punchr <!-- omit in toc -->
 
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
@@ -19,7 +19,29 @@ Specifically, this repo contains:
 
 - [Register here](https://forms.gle/ueNS5iGQup6oszCQ8)
 
-## Table of Contents
+# Table of Contents <!-- omit in toc -->
+- [Background](#background)
+- [Outcomes](#outcomes)
+  - [Hole Punch Outcomes](#hole-punch-outcomes)
+  - [Hole Punch Attempt Outcomes](#hole-punch-attempt-outcomes)
+- [Components](#components)
+  - [`honeypot`](#honeypot)
+  - [`server`](#server)
+  - [`go-client`](#go-client)
+  - [`rust-client`](#rust-client)
+- [Install](#install)
+- [Development](#development)
+- [Deployment](#deployment)
+  - [Clients](#clients)
+    - [RaspberryPi](#raspberrypi)
+    - [NixOS](#nixos)
+- [Server](#server-1)
+- [Honeypot](#honeypot-1)
+- [Release](#release)
+  - [go-client](#go-client-1)
+- [Maintainers](#maintainers)
+- [Contributing](#contributing)
+- [License](#license)
 
 - [Table of Contents](#table-of-contents)
 - [Background](#background)
@@ -30,7 +52,7 @@ Specifically, this repo contains:
 - [Contributing](#contributing)
 - [License](#license)
 
-## Background
+# Background
 
 ![punchr flow diagram](./docs/punchr.drawio.png)
 
@@ -60,9 +82,9 @@ Any connection to a remote peer can consist of multiple attempts to hole punch a
 6. `FAILED` - We exchanged `CONNECT` and `SYNC` messages on the `/libp2p/dcutr` stream but the final direct connection attempt failed -> the hole punch was unsuccessful
 7. `SUCCESS` - We were able to directly connect to the remote peer.
 
-## Components
+# Components
 
-### `honeypot`
+## `honeypot`
 
 The honeypot operates as a DHT server and periodically walks the complete DHT to announce itself to the network. The idea is that other peers add the honeypot to their routing table. This increases the chances of peers behind NATs passing by the honeypot when they request information from the DHT network.
 
@@ -98,7 +120,7 @@ GLOBAL OPTIONS:
    --telemetry-port value  On which port should the telemetry (prometheus, pprof) server listen (default: 11001) [$PUNCHR_HONEYPOT_TELEMETRY_PORT]
    --version, -v           print the version (default: false)
 ```
-### `server`
+## `server`
 
 The server exposes a gRPC api that allows clients to query for recently seen NAT'ed DCUtR capable peers that can be probed and then report the result of the hole punching process back.
 
@@ -131,7 +153,7 @@ GLOBAL OPTIONS:
    --version, -v           print the version (default: false)
 ```
 
-### `go-client`
+## `go-client`
 
 The client announces itself to the server and then periodically queries the server for peers to hole punch. If the server returns address information the client connects to the remote peer via the relay and waits for the remote to initiate a hole punch. Finally, the outcome gets reported back to the server.
 
@@ -170,7 +192,7 @@ Resource requirements:
 - `Memory` - `~100MB`
 - `CPU` - `~2.5%`
 
-### `rust-client`
+## `rust-client`
 
 Rust implementation of the punchr client.
 
@@ -195,14 +217,14 @@ OPTIONS:
 Note: The api key for authentication is read from env value "API_KEY".
 ```
 
-## Install
+# Install
 
 Head over to the [GitHub releases page](https://github.com/dennis-tra/punchr/releases) and download the appropriate binary or compile it yourself. 
 Run `make build` and find the executables in the `dist` folder. When running the honeypot or server the database migrations folder `./migrations` needs to be in the working directory of either process.
 
 The honeypot listens on port `10000`, the server on port `11000` and clients on `12000`. All components expose prometheus and pprof telemetry on `10001`, `11001`, and `12001` respectively.
 
-## Development
+# Development
 
 Run `make tools` to install all necessary tools for code generation (protobuf and database models). Specifically, this will run:
 
@@ -229,11 +251,11 @@ migrate create -ext sql -dir migrations -seq create_some_table
 make migrate-up
 ```
 
-## Deployment
+# Deployment
 
-### Clients
+## Clients
 
-#### RaspberryPi
+### RaspberryPi
 
 Download a `linux_armv6` or `linux_armv7` release from the [GitHub releases page](https://github.com/dennis-tra/punchr/releases). Then you could install a systemd service at `/etc/systemd/system/punchrclient.service`:
 
@@ -264,7 +286,7 @@ If the client can't connect to bootstrap peers try this additional command line 
 --bootstrap-peers="/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/ip4/147.75.77.187/tcp/4001/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/ip4/147.75.109.29/tcp/4001/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp"
 ```
 
-#### NixOS
+### NixOS
 
 If you're running NixOS, you can get the client systemd service with the NixOS
 Module included in the flake.
@@ -289,7 +311,7 @@ Usage:
 
 You can run the client by itself with `nix run github:dennis-tra/punchr#client`.
 
-## Server
+# Server
 
 Systemd service example at `/etc/systemd/system/punchr-server.service`:
 
@@ -314,7 +336,7 @@ To start the service run:
 sudo service punchr-client start
 ```
 
-## Honeypot
+# Honeypot
 
 Systemd service example at `/etc/systemd/system/punchr-honeypot.service`:
 
@@ -339,23 +361,23 @@ To start the service run:
 sudo service punchr-honeypot start
 ```
 
-## Release
+# Release
 
-### go-client
+## go-client
 
 Tag a commit with a semantic version and this will trigger a GitHub-Action. This will build go-client binaries for several platforms and create a new GitHub release.
 
-## Maintainers
+# Maintainers
 
 [@dennis-tra](https://github.com/dennis-tra)
 
 
-## Contributing
+# Contributing
 
 Feel free to dive in! [Open an issue](https://github.com/RichardLitt/standard-readme/issues/new) or submit PRs.
 
 Standard Readme follows the [Contributor Covenant](http://contributor-covenant.org/version/1/3/0/) Code of Conduct.
 
-## License
+# License
 
 [Apache License Version 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ If the client can't connect to bootstrap peers try this additional command line 
 
 ### NixOS
 
-If you're running NixOS, you can get the client systemd service with the NixOS
-Module included in the flake.
+If you're running NixOS, you can use the client option with the NixOS Module
+included in the flake.
 
 Usage:
 ```nix

--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ Usage:
       {
          imports = [ inputs.punchr.nixosModules.client ];
          services.punchr-client.apiKey = "<API-KEY>";
+
+         # Make sure this is readable/writable by the `punchr` user or `punchr` group.
+         services.punchr-client.clientKeyFile = "/var/lib/punchr/client.keys"; # default value
       }
   };
 }

--- a/cmd/client/host.go
+++ b/cmd/client/host.go
@@ -115,6 +115,7 @@ func (h *Host) Bootstrap(ctx context.Context) error {
 		log.WithField("remoteID", util.FmtPeerID(bp.ID)).Info("Connecting to bootstrap peer...")
 		if err := h.Connect(ctx, bp); err != nil {
 			log.Warn("Error connecting to bootstrap peer", bp)
+			errCount++
 			lastErr = errors.Wrap(err, "connecting to bootstrap peer")
 		}
 	}

--- a/cmd/client/host.go
+++ b/cmd/client/host.go
@@ -109,11 +109,18 @@ func (h *Host) logEntry(remoteID peer.ID) *log.Entry {
 
 // Bootstrap connects this host to bootstrap peers.
 func (h *Host) Bootstrap(ctx context.Context) error {
+	errCount := 0
+	var lastErr error
 	for _, bp := range h.bpAddrInfos {
 		log.WithField("remoteID", util.FmtPeerID(bp.ID)).Info("Connecting to bootstrap peer...")
 		if err := h.Connect(ctx, bp); err != nil {
-			return errors.Wrap(err, "connecting to bootstrap peer")
+			log.Warn("Error connecting to bootstrap peer", bp)
+			lastErr = errors.Wrap(err, "connecting to bootstrap peer")
 		}
+	}
+
+	if errCount == len(h.bpAddrInfos) {
+		return lastErr
 	}
 
 	return nil

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660661643,
+        "narHash": "sha256-WlgPb7KLTZUeY31o9HWhu37pvgA76MKwakaXefkaIB4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a82127cea64fd801c5e138ae23dfd444ec1e06d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  description = "Punchr";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/release-22.05";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    (flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          system = system;
+        };
+      in
+      {
+        packages.client = pkgs.buildGo118Module rec {
+          src = ./.;
+
+          pname = "client";
+          version = "0.4.0";
+          subPackages = [ "cmd/client" ];
+          checkPhase = "";
+
+
+          # Sha of go modules. To update uncomment the below line and comment
+          # out the current sha. Then update the sha.
+          # vendorSha256 = pkgs.lib.fakeSha256;
+          vendorSha256 = "sha256-nb0oq3vA8ANlppmpKzL61n6eS96eXiBI6Mumxu00rII=";
+
+          meta = with pkgs.lib; {
+            description = "";
+            homepage = "https://github.com/dennis-tra/punchr";
+            license = licenses.mit;
+            maintainers = with maintainers; [ "marcopolo" ];
+            platforms = platforms.linux ++ platforms.darwin;
+          };
+        };
+        defaultPackage = self.packages.${system}.client;
+        devShell = pkgs.mkShell {
+          buildInputs = [ pkgs.go ];
+        };
+      })) // {
+      nixosModules.client = { config, pkgs, ... }:
+        let cfg = config.services.punchr-client;
+        in
+        {
+          options.services.punchr-client = {
+            apiKey = nixpkgs.lib.mkOption {
+              description = "Punchr API Key";
+              type = nixpkgs.lib.types.str;
+            };
+            clientKeyFile = nixpkgs.lib.mkOption {
+              description = "Path to file where punchr saves the host identities. Should be writable by punchr-client";
+              type = nixpkgs.lib.types.str;
+              default = "/var/lib/punchr/client.keys";
+              example = "/var/lib/punchr/client.keys";
+            };
+            bootstrapPeers = nixpkgs.lib.mkOption {
+              description = "Comma separated list of multi addresses of bootstrap peers  (accepts multiple inputs)";
+              type = nixpkgs.lib.types.str;
+              default = "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN,/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt,/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ,/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb,/ip4/147.75.77.187/tcp/4001/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa,/ip4/147.75.109.29/tcp/4001/p2p/QmZa1sAxajnQjVM8WjWXoMbmPd7NsWhfKsPkErzpm9wGkp";
+              example = "/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb";
+            };
+          };
+          config = {
+            users.users.punchr.isSystemUser = true;
+            users.users.punchr.group = "punchr";
+            users.groups.punchr = { };
+            systemd.services.punchr-client = {
+              description = "punchr-client";
+              wantedBy = [ "multi-user.target" ];
+              after = [ "network.target" ];
+              serviceConfig = {
+                Environment = "PUNCHR_CLIENT_API_KEY=${cfg.apiKey} PUNCHR_CLIENT_KEY_FILE=${cfg.clientKeyFile} NEBULA_BOOTSTRAP_PEERS=${cfg.bootstrapPeers}";
+                ExecStart = "${
+                  self.packages.${pkgs.system}.client
+                  }/bin/client";
+                Restart = "always";
+                RestartSec = "1min";
+                User = "punchr";
+              };
+            };
+          };
+        };
+    };
+}


### PR DESCRIPTION
On both my Linux home server and Pi4 I would fail to connect to at least one of the bootstrap peers and punchr-client would fail to start. They both run NixOS so that may be related (but unclear why?).

This makes the change that allows punchr-client to continue even if it failed to connect to some bootstrap nodes. And only fail to start if the client fails to connect to all bootstrap nodes.

This also includes a change to make it even easier to get a punchr-client up and running with NixOS. Users can reference this repo and provide an api key and this module will automatically build the project and setup a systemd service.

Also a couple minor changes around readme formatting.