### PR TITLE
rust-client: Update to proto changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # v1.1.2
+
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -24,7 +27,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
+      
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.1.6", features = ["derive"]}
+clap = { version = "4.0.26", features = ["derive"]}
 env_logger = "0.9"
 either = "1.6.1"
 futures = "0.3"
-futures-timer = "2"
-libp2p = { version = "0.46.1", default-features = false, features = ["dcutr", "dns-async-std", "identify", "noise", "relay", "ping", "tcp-async-io", "yamux"] }
+futures-timer = "3.0.0"
+libp2p = { version = "0.49.0", default-features = false, features = ["async-std", "dcutr", "dns", "identify", "noise", "relay", "ping", "tcp", "yamux"] }
 log = "0.4"
-prost = "0.9"
+prost = "0.11.2"
 rand = "0.8.5"   
 tokio = { version = "1.0", features = [ "rt-multi-thread", "time", "fs", "macros", "net",] }
-tonic = { version = "0.6", features = ["tls"] }
+tonic = { version = "0.8.2", features = ["tls"] }
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.8.2"

--- a/rust-client/src/main.rs
+++ b/rust-client/src/main.rs
@@ -28,6 +28,7 @@ use std::ops::ControlFlow;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tonic::transport::{Certificate, ClientTlsConfig, Endpoint};
 
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod grpc {
     tonic::include_proto!("_");
 }
@@ -277,6 +278,10 @@ impl HolePunchState {
             ended_at: 0,
             listen_multi_addresses: client_listen_addrs.map(|a| a.to_vec()).collect(),
             api_key,
+            protocols: Vec::new(),
+            latency_measurements: Vec::new(),
+            network_information: None,
+            nat_mappings: Vec::new(),
         };
         HolePunchState {
             request,

--- a/rust-client/src/main.rs
+++ b/rust-client/src/main.rs
@@ -4,12 +4,8 @@ use futures::stream::StreamExt;
 use libp2p::core::multiaddr::{Multiaddr, Protocol};
 use libp2p::core::transport::OrTransport;
 use libp2p::core::{upgrade, ConnectedPoint, ProtocolName, UpgradeInfo};
-use libp2p::dcutr;
 use libp2p::dcutr::behaviour::UpgradeError;
 use libp2p::dns::DnsConfig;
-use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
-use libp2p::noise;
-use libp2p::ping::{Ping, PingConfig, PingEvent};
 use libp2p::relay::v2::client::{self, Client};
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{
@@ -17,8 +13,8 @@ use libp2p::swarm::{
     SwarmBuilder, SwarmEvent,
 };
 use libp2p::tcp::{GenTcpConfig, TcpTransport};
-use libp2p::Transport;
-use libp2p::{identity, PeerId};
+use libp2p::{dcutr, identify, identity, noise, ping};
+use libp2p::{PeerId, Transport};
 use log::{info, warn};
 use std::convert::TryInto;
 use std::env;
@@ -208,13 +204,13 @@ async fn init_swarm(
     .multiplex(libp2p::yamux::YamuxConfig::default())
     .boxed();
 
-    let identify_config = IdentifyConfig::new("/ipfs/0.1.0".to_string(), local_key.public())
+    let identify_config = identify::Config::new("/ipfs/0.1.0".to_string(), local_key.public())
         .with_agent_version(agent_version());
 
     let behaviour = Behaviour {
         relay: relay_behaviour,
-        ping: Ping::new(PingConfig::new()),
-        identify: Identify::new(identify_config),
+        ping: ping::Behaviour::new(ping::Config::new()),
+        identify: identify::Behaviour::new(identify_config),
         dcutr: dcutr::behaviour::Behaviour::new(),
     };
 
@@ -554,28 +550,28 @@ fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
 #[behaviour(out_event = "Event", event_process = false)]
 struct Behaviour {
     relay: Client,
-    ping: Ping,
-    identify: Identify,
+    ping: ping::Behaviour,
+    identify: identify::Behaviour,
     dcutr: dcutr::behaviour::Behaviour,
 }
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum Event {
-    Ping(PingEvent),
-    Identify(IdentifyEvent),
+    Ping(ping::Event),
+    Identify(identify::Event),
     Relay(client::Event),
     Dcutr(dcutr::behaviour::Event),
 }
 
-impl From<PingEvent> for Event {
-    fn from(e: PingEvent) -> Self {
+impl From<ping::Event> for Event {
+    fn from(e: ping::Event) -> Self {
         Event::Ping(e)
     }
 }
 
-impl From<IdentifyEvent> for Event {
-    fn from(e: IdentifyEvent) -> Self {
+impl From<identify::Event> for Event {
+    fn from(e: identify::Event) -> Self {
         Event::Identify(e)
     }
 }


### PR DESCRIPTION
- Updates the rust-client to `libp2pv0.49.0`

- Fixes issue #37.
Unfortunately for none of the new properties we have all of the required information exposed in rust-libp2p. Thus we right now just leave them empty. The only thing we might be able to add is the `network_information`. However, that would require some more work and I am not sure if it's high priority. @dennis-tra does the `network_information`  have major relevance in your analysis?