### PR TITLE
trying to patch docker on linux amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,19 +17,19 @@ build-honeypot:
 	go build -ldflags="-X 'main.Version=$(VERSION_HONEYPOT)'" -o dist/punchrhoneypot cmd/honeypot/*.go
 
 build-client:
-	go build -ldflags="-X 'main.Version=$(VERSION_CLIENT)'" -o dist/punchrclient cmd/client/*.go
+	go build -ldflags="-s -w -X 'main.Version=$(VERSION_CLIENT)'" -o dist/punchrclient cmd/client/*.go
 
 build-server:
 	go build -ldflags="-X 'main.Version=$(VERSION_SERVER)'" -o dist/punchrserver cmd/server/*.go
 
 docker-client:
-	docker build -t dennistra/punchr-client:latest -t dennistra/punchr-client:$(VERSION_CLIENT) -f docker/Dockerfile_client .
+	docker build --platform linux/amd64 -t dennistra/punchr-client:latest -t dennistra/punchr-client:$(VERSION_CLIENT) -f docker/Dockerfile_client .
 
 docker-server:
-	docker build -t dennistra/punchr-server:latest -t dennistra/punchr-server:$(VERSION_SERVER) -f docker/Dockerfile_server .
+	docker build --platform linux/amd64 -t dennistra/punchr-server:latest -t dennistra/punchr-server:$(VERSION_SERVER) -f docker/Dockerfile_server .
 
 docker-honeypot:
-	docker build -t dennistra/punchr-honeypot:latest -t dennistra/punchr-honeypot:$(VERSION_HONEYPOT) -f docker/Dockerfile_honeypot .
+	docker build --platform linux/amd64 -t dennistra/punchr-honeypot:latest -t dennistra/punchr-honeypot:$(VERSION_HONEYPOT) -f docker/Dockerfile_honeypot .
 
 format:
 	gofumpt -w -l .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,12 @@ services:
     image: dennistra/punchr-client:latest
     container_name: punchr_client
     restart: always
-    user: punchr
     environment:
       # More option at pkg/client/app.go
       PUNCHR_CLIENT_API_KEY: # Add your API key here
     network_mode: host
+    volumes:
+      - punchr_config:/root/.config/punchr/
+
+volumes:
+  punchr_config:

--- a/docker/Dockerfile_client
+++ b/docker/Dockerfile_client
@@ -1,4 +1,3 @@
-# Build nebula
 FROM golang:1.19 AS builder
 
 WORKDIR /build
@@ -7,14 +6,12 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'main.Version=$(cat cmd/client/version)'" -o dist/punchrclient cmd/client/*.go
+RUN CGO_ENABLED=0 make build-client
 
 # Create lightweight container to run nebula
 FROM alpine:latest
 
-RUN adduser -D -H punchr
-USER punchr
-WORKDIR /home/punchr
+WORKDIR /root
 
 COPY --from=builder /build/dist/punchrclient /usr/local/bin/punchr
 CMD punchr


### PR DESCRIPTION
According to https://dev.to/lakhansamani/create-docker-image-on-apple-silicon-m1-mac-2f75, it seems that M1 Mac support both linux/arm64 and linux/amd64 images, since this is meant to run on commodity hardware, the most common architecture being amd64 it makes sense to switch to it.

This also:
- fixes the current docker images so that it runs on linux. (User root instead of a dedicated user since it's inside of a container anyway.)
- add a named volume so that docker-compose users have their `.config/punchr` files persisted across reboots
- adds the `-s -w` ldflags to the go build, removing debug strings, bringing the binary size down from 41MB to ~28MB (and thus also the docker image size)