### PR TITLE
README: Store systemd file as punchr-client.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ make migrate-up
 
 ### RaspberryPi
 
-Download a `linux_armv6` or `linux_armv7` release from the [GitHub releases page](https://github.com/dennis-tra/punchr/releases). Then you could install a systemd service at `/etc/systemd/system/punchrclient.service`:
+Download a `linux_armv6` or `linux_armv7` release from the [GitHub releases page](https://github.com/dennis-tra/punchr/releases). Then you could install a systemd service at `/etc/systemd/system/punchr-client.service`:
 
 ```text
 [Unit]


### PR DESCRIPTION
To be consistent with the command below it and the release notes.
```shell
sudo service punchr-client start
```