### PR TITLE
README/systemd: Wait for network-online.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Download a `linux_armv6` or `linux_armv7` release from the [GitHub releases page
 ```text
 [Unit]
 Description=Punchr Client
-After=network.target
+After=network-online.target
 
 [Service]
 User=pi


### PR DESCRIPTION
I suggest waiting for `network-online.target` instead of `network.target`. If I understand correctly, this waits for the network to be up AND online.

> Note the distinction between this unit [network-online.target] and network.target. This unit is an active unit (i.e. pulled in by the consumer rather than the provider of this functionality) and pulls in a service which possibly adds substantial delays to further execution. In contrast, network.target is a passive unit (i.e. pulled in by the provider of the functionality, rather than the consumer) that usually does not delay execution much. Usually, network.target is part of the boot of most systems, while network-online.target is not, except when at least one unit requires it. Also see Running Services After the Network Is Up for more information.

https://www.freedesktop.org/software/systemd/man/systemd.special.html

With `Restart=on-failure` this is likely not too important. In addition, my systemd skills are bare minimum. Thus feel free to ignore.