### PR TITLE
rust-client: Listen on IPv6

### DIFF
--- a/rust-client/src/main.rs
+++ b/rust-client/src/main.rs
@@ -19,7 +19,7 @@ use libp2p::{PeerId, Transport};
 use log::{info, warn};
 use std::convert::TryInto;
 use std::env;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::num::NonZeroU32;
 use std::ops::ControlFlow;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -227,18 +227,25 @@ async fn init_swarm(
         .dial_concurrency_factor(10_u8.try_into()?)
         .build();
 
-    swarm.listen_on(
-        Multiaddr::empty()
-            .with("0.0.0.0".parse::<Ipv4Addr>()?.into())
-            .with(Protocol::Tcp(0)),
-    )?;
+    for ip_addr_version in [
+        Protocol::from(Ipv4Addr::UNSPECIFIED),
+        Protocol::from(Ipv6Addr::UNSPECIFIED),
+    ]
+    .into_iter()
+    {
+        swarm.listen_on(
+            Multiaddr::empty()
+                .with(ip_addr_version.clone())
+                .with(Protocol::Tcp(0)),
+        )?;
 
-    swarm.listen_on(
-        Multiaddr::empty()
-            .with("0.0.0.0".parse::<Ipv4Addr>()?.into())
-            .with(Protocol::Udp(0))
-            .with(Protocol::Quic),
-    )?;
+        swarm.listen_on(
+            Multiaddr::empty()
+                .with(ip_addr_version)
+                .with(Protocol::Udp(0))
+                .with(Protocol::Quic),
+        )?;
+    }
 
     // Wait to listen on all interfaces.
     let mut delay = futures_timer::Delay::new(std::time::Duration::from_secs(1)).fuse();


### PR DESCRIPTION
To support hole punching on IPv6, the rust-client should listen on IPv6 for incoming TCP and QUIC connections.