### PR TITLE
rust-client: handle address parsing error gracefully

### DIFF
--- a/rust-client/src/main.rs
+++ b/rust-client/src/main.rs
@@ -139,8 +139,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .multi_addresses
             .clone()
             .into_iter()
-            .map(Multiaddr::try_from)
-            .collect::<Result<Vec<_>, libp2p::multiaddr::Error>>()?;
+            .filter_map(|a| Multiaddr::try_from(a).ok())
+            .collect::<Vec<_>>();
 
         let state = HolePunchState::new(
             local_peer_id,
@@ -355,7 +355,7 @@ impl HolePunchState {
             self.request
                 .remote_multi_addresses
                 .iter()
-                .map(|a| Multiaddr::try_from(a.clone()).unwrap())
+                .filter_map(|a| Multiaddr::try_from(a.clone()).ok())
                 .collect::<Vec<_>>(),
             reason
         );


### PR DESCRIPTION
The multiaddress of a remote peer may contain a Protocol that is not yet implemented in `rust-multiaddr`. 
This causes the parsing from `Vec` to `Multiaddr` to fail. Right now this results in an error that aborts the whole program.
This PR changes the implementation to simply skip an address that we can not parse.

Reported in https://github.com/dennis-tra/punchr/issues/62#issuecomment-1336513932.